### PR TITLE
Add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+This repository is governed by the Quansight Repository Code of Conduct. It
+can be found here:
+https://github.com/Quansight/.github/blob/master/CODE_OF_CONDUCT.md.


### PR DESCRIPTION
This adds CODE_OF_CONDUCT.md. The contents of this file point back to the
actual Quansight Code of Conduct at
https://github.com/Quansight/.github/blob/master/CODE_OF_CONDUCT.md.

See https://github.com/Quansight/.github/issues/8 for more information.
